### PR TITLE
FIX: Remove git lfs dependencies

### DIFF
--- a/examples/CentralParkSoil/A.npy
+++ b/examples/CentralParkSoil/A.npy
@@ -1,3 +1,1 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f8a6bd602a38cb1cdf3d4da0d3e797c5d964e5ef4f1954a33d6118d7b5384ed0
-size 100126656
+

--- a/examples/Tara/A.npy
+++ b/examples/Tara/A.npy
@@ -1,3 +1,1 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a6520679272e52f3b28849946fd0cb2e91c047bdda773259765b17ed88c72e53
-size 685818848
+


### PR DESCRIPTION
due to LFS quota being exceeded atm this repos can't be cloned - so this is a quickfix